### PR TITLE
Fix local runner ParserException caused by BigQuery backtick identifiers

### DIFF
--- a/gcp_ml_framework/components/ingestion/bigquery_extract.py
+++ b/gcp_ml_framework/components/ingestion/bigquery_extract.py
@@ -83,8 +83,9 @@ class BigQueryExtract(BaseComponent):
             gcs_prefix=context.gcs_prefix,
             run_date=run_date or "2024-01-01",
         )
+        # DuckDB uses ANSI double-quote identifier quoting; BigQuery uses backticks.
+        rendered = rendered.replace("`", '"')
         out_dir = tempfile.mkdtemp(prefix=f"gml_{self.output_table}_")
         out_path = os.path.join(out_dir, "output.parquet")
-        # DuckDB can execute most BigQuery-compatible SQL dialects
         duckdb.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")
         return out_path

--- a/gcp_ml_framework/components/transformation/bq_transform.py
+++ b/gcp_ml_framework/components/transformation/bq_transform.py
@@ -96,6 +96,8 @@ class BQTransform(BaseComponent):
             gcs_prefix=context.gcs_prefix,
             run_date=run_date or "2024-01-01",
         )
+        # DuckDB uses ANSI double-quote identifier quoting; BigQuery uses backticks.
+        rendered = rendered.replace("`", '"')
         out_dir = tempfile.mkdtemp(prefix=f"gml_{self.output_table}_")
         out_path = os.path.join(out_dir, f"{self.output_table}.parquet")
         duckdb.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")


### PR DESCRIPTION
DuckDB (used by the local runner) follows ANSI SQL and requires double-quote identifier quoting. BigQuery SQL uses backticks, which DuckDB's parser rejects with "syntax error at or near '`'". Translate backticks to double-quotes on the rendered SQL in both BigQueryExtract.local_run() and BQTransform.local_run() before handing the query to DuckDB.

https://claude.ai/code/session_01UVBS26DVuvgJp4kFyTeXYR