### PR TITLE
Fix local runner CatalogException by adding DuckDB seed and registration

### DIFF
--- a/gcp_ml_framework/cli/cmd_run.py
+++ b/gcp_ml_framework/cli/cmd_run.py
@@ -53,7 +53,8 @@ def run_local(
     )
     pipeline_def = _load_pipeline(pipeline_dir)
 
-    runner = LocalRunner(ctx)
+    seeds_dir = pipeline_dir / "seeds"
+    runner = LocalRunner(ctx, seeds_dir=seeds_dir if seeds_dir.exists() else None)
     if dry_run:
         runner.print_plan(pipeline_def)
     else:

--- a/gcp_ml_framework/pipeline/runner.py
+++ b/gcp_ml_framework/pipeline/runner.py
@@ -25,10 +25,75 @@ class LocalRunner:
     - Local iteration without GCP access
     - Unit and integration tests
     - CI compile-only checks (--dry-run)
+
+    Seed data
+    ---------
+    SQL-based components (BigQueryExtract, BQTransform) query DuckDB by the
+    branch-namespaced table name, e.g. ``"dsci_churn_pred_main"."raw_events"``.
+    Two mechanisms populate those tables automatically:
+
+    1. **Seed files** — place ``seeds/<table_name>.csv`` (or ``.parquet``) in the
+       pipeline directory.  ``_seed_duckdb()`` loads them into DuckDB before the
+       first step runs.
+
+    2. **Intermediate registration** — after each step ``_register_output()``
+       registers the step's Parquet output as a DuckDB table so that downstream
+       SQL transforms can reference it by name.
     """
 
-    def __init__(self, context: "MLContext") -> None:
+    def __init__(self, context: "MLContext", seeds_dir: Path | None = None) -> None:
         self._ctx = context
+        self._seeds_dir = Path(seeds_dir) if seeds_dir else None
+
+    def _seed_duckdb(self) -> None:
+        """Pre-populate DuckDB with fixture data from the seeds/ directory.
+
+        Any ``.csv`` or ``.parquet`` file in ``seeds_dir`` is loaded as a table
+        named ``<bq_dataset>.<stem>`` so that ingestion SQL can reference it.
+        """
+        if not self._seeds_dir or not self._seeds_dir.exists():
+            return
+
+        import duckdb
+
+        dataset = self._ctx.bq_dataset
+        duckdb.sql(f'CREATE SCHEMA IF NOT EXISTS "{dataset}"')
+
+        for seed_file in sorted(self._seeds_dir.iterdir()):
+            if seed_file.suffix == ".parquet":
+                reader = f"read_parquet('{seed_file.as_posix()}')"
+            elif seed_file.suffix == ".csv":
+                reader = f"read_csv_auto('{seed_file.as_posix()}')"
+            else:
+                continue
+
+            table_name = seed_file.stem
+            duckdb.sql(
+                f'CREATE OR REPLACE TABLE "{dataset}"."{table_name}" '
+                f"AS SELECT * FROM {reader}"
+            )
+            print(f"[local]   seeded  {dataset}.{table_name}  ({seed_file.name})")
+
+    def _register_output(self, component: Any, result: Any) -> None:
+        """Register a step's Parquet output as a DuckDB table.
+
+        This makes intermediate outputs (e.g. ``churn_training_raw``) queryable
+        by name in downstream SQL transforms without any extra configuration.
+        """
+        if not isinstance(result, str) or not result.endswith(".parquet"):
+            return
+        if not hasattr(component, "output_table"):
+            return
+
+        import duckdb
+
+        dataset = self._ctx.bq_dataset
+        table_name = component.output_table
+        duckdb.sql(
+            f'CREATE OR REPLACE TABLE "{dataset}"."{table_name}" '
+            f"AS SELECT * FROM read_parquet('{result}')"
+        )
+        print(f"[local]   registered  {dataset}.{table_name}")
 
     def print_plan(self, pipeline_def: "PipelineDefinition") -> None:
         print(f"\nPipeline: {pipeline_def.name!r}  (schedule={pipeline_def.schedule!r})")
@@ -50,6 +115,8 @@ class LocalRunner:
 
         Returns a dict of {step_name: output}.
         """
+        self._seed_duckdb()
+
         outputs: dict[str, Any] = {}
         prev_output: Any = None
 
@@ -68,6 +135,7 @@ class LocalRunner:
                 result = step.component.local_run(self._ctx, **kwargs)
                 outputs[step.name] = result
                 prev_output = result
+                self._register_output(step.component, result)
                 print(f"[local]   → {result}")
             except Exception as exc:
                 print(f"[local]   FAILED: {exc}")

--- a/pipelines/example_churn/seeds/raw_user_events.csv
+++ b/pipelines/example_churn/seeds/raw_user_events.csv
@@ -1,0 +1,11 @@
+user_id,session_count_7d,session_count_30d,total_purchases_30d,days_since_last_login,support_tickets_90d,avg_session_duration_s,churned_within_30d,event_date
+u001,12,45,3,2,0,320.5,false,2023-12-20
+u002,3,8,0,15,2,95.0,true,2023-12-18
+u003,25,90,12,1,0,540.2,false,2023-12-22
+u004,1,2,0,30,4,45.0,true,2023-11-30
+u005,8,30,5,5,1,280.0,false,2023-12-15
+u006,0,1,0,60,3,20.0,true,2023-10-15
+u007,18,70,8,3,0,410.8,false,2023-12-21
+u008,5,12,1,12,1,150.3,false,2023-12-10
+u009,2,5,0,25,2,60.0,true,2023-12-01
+u010,30,110,20,1,0,620.0,false,2023-12-23


### PR DESCRIPTION
Two issues caused "table does not exist" errors during local pipeline runs:

1. No seed data — DuckDB starts empty so ingestion SQL had no tables to query. LocalRunner now accepts a seeds_dir and calls _seed_duckdb() before the first step, loading any .csv/.parquet file in seeds/ as a DuckDB table under the branch-namespaced schema (e.g. dsci_example_churn_main.raw_user_events).

2. Intermediate outputs not visible to downstream SQL — BQTransform queries the previous step's output by table name, but the runner only passed the Parquet path via input_path without registering it in DuckDB. _register_output() now registers each step's Parquet result as a DuckDB table immediately after it completes, making it available to subsequent SQL transforms by name.

cmd_run.py auto-detects pipelines/<name>/seeds/ and passes it to LocalRunner. Added raw_user_events.csv seed fixture for the example_churn pipeline.

https://claude.ai/code/session_01UVBS26DVuvgJp4kFyTeXYR