### PR TITLE
Fix CatalogException by sharing a single DuckDB connection across loc…

### DIFF
--- a/gcp_ml_framework/components/ingestion/bigquery_extract.py
+++ b/gcp_ml_framework/components/ingestion/bigquery_extract.py
@@ -78,6 +78,10 @@ class BigQueryExtract(BaseComponent):
         import tempfile
         import os
 
+        # Use the shared connection from LocalRunner so seeded tables are visible.
+        # Fall back to a fresh connection when called outside the runner (e.g. tests).
+        conn: duckdb.DuckDBPyConnection = kwargs.get("db_conn") or duckdb.connect()
+
         rendered = self.query.format(
             bq_dataset=context.bq_dataset,
             gcs_prefix=context.gcs_prefix,
@@ -87,5 +91,5 @@ class BigQueryExtract(BaseComponent):
         rendered = rendered.replace("`", '"')
         out_dir = tempfile.mkdtemp(prefix=f"gml_{self.output_table}_")
         out_path = os.path.join(out_dir, "output.parquet")
-        duckdb.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")
+        conn.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")
         return out_path

--- a/gcp_ml_framework/components/transformation/bq_transform.py
+++ b/gcp_ml_framework/components/transformation/bq_transform.py
@@ -90,6 +90,10 @@ class BQTransform(BaseComponent):
         import tempfile
         import os
 
+        # Use the shared connection from LocalRunner so intermediate tables are visible.
+        # Fall back to a fresh connection when called outside the runner (e.g. tests).
+        conn: duckdb.DuckDBPyConnection = kwargs.get("db_conn") or duckdb.connect()
+
         sql = self._get_sql()
         rendered = sql.format(
             bq_dataset=context.bq_dataset,
@@ -100,7 +104,7 @@ class BQTransform(BaseComponent):
         rendered = rendered.replace("`", '"')
         out_dir = tempfile.mkdtemp(prefix=f"gml_{self.output_table}_")
         out_path = os.path.join(out_dir, f"{self.output_table}.parquet")
-        duckdb.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")
+        conn.sql(f"COPY ({rendered}) TO '{out_path}' (FORMAT PARQUET)")
         return out_path
 
 

--- a/gcp_ml_framework/pipeline/runner.py
+++ b/gcp_ml_framework/pipeline/runner.py
@@ -7,6 +7,7 @@ VertexRunner  — submits a compiled KFP YAML to Vertex AI Pipelines.
 
 from __future__ import annotations
 
+import duckdb
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -44,6 +45,9 @@ class LocalRunner:
     def __init__(self, context: "MLContext", seeds_dir: Path | None = None) -> None:
         self._ctx = context
         self._seeds_dir = Path(seeds_dir) if seeds_dir else None
+        # Single persistent in-memory connection shared across all steps so that
+        # seeded tables and intermediate outputs are visible to every local_run().
+        self._conn = duckdb.connect()
 
     def _seed_duckdb(self) -> None:
         """Pre-populate DuckDB with fixture data from the seeds/ directory.
@@ -54,10 +58,8 @@ class LocalRunner:
         if not self._seeds_dir or not self._seeds_dir.exists():
             return
 
-        import duckdb
-
         dataset = self._ctx.bq_dataset
-        duckdb.sql(f'CREATE SCHEMA IF NOT EXISTS "{dataset}"')
+        self._conn.sql(f'CREATE SCHEMA IF NOT EXISTS "{dataset}"')
 
         for seed_file in sorted(self._seeds_dir.iterdir()):
             if seed_file.suffix == ".parquet":
@@ -68,7 +70,7 @@ class LocalRunner:
                 continue
 
             table_name = seed_file.stem
-            duckdb.sql(
+            self._conn.sql(
                 f'CREATE OR REPLACE TABLE "{dataset}"."{table_name}" '
                 f"AS SELECT * FROM {reader}"
             )
@@ -85,11 +87,9 @@ class LocalRunner:
         if not hasattr(component, "output_table"):
             return
 
-        import duckdb
-
         dataset = self._ctx.bq_dataset
         table_name = component.output_table
-        duckdb.sql(
+        self._conn.sql(
             f'CREATE OR REPLACE TABLE "{dataset}"."{table_name}" '
             f"AS SELECT * FROM read_parquet('{result}')"
         )
@@ -127,7 +127,7 @@ class LocalRunner:
 
             print(f"[local] {step.name} ({step.component.__class__.__name__}) ...")
             try:
-                kwargs: dict[str, Any] = {"run_date": run_date}
+                kwargs: dict[str, Any] = {"run_date": run_date, "db_conn": self._conn}
                 # Wire the previous step's output as input to the next step
                 if prev_output is not None:
                     kwargs["input_path"] = prev_output


### PR DESCRIPTION
…al run

duckdb.sql() does not guarantee the same underlying connection object across separate call sites. _seed_duckdb() was seeding one connection while BigQueryExtract/BQTransform.local_run() were each opening fresh empty ones, so seeded tables were invisible at query time.

Fix: LocalRunner.__init__ creates one duckdb.connect() stored as self._conn. _seed_duckdb() and _register_output() use self._conn directly. The connection is passed to every local_run() call as a db_conn kwarg. BigQueryExtract and BQTransform extract db_conn from kwargs and use it for all SQL execution, falling back to a fresh connection only when called outside the runner.

https://claude.ai/code/session_01UVBS26DVuvgJp4kFyTeXYR